### PR TITLE
Fixup link to logo to point directly to asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# randgen <a href='https://github.com/benyamindsmith/randngen'><img src='https://github.com/benyamindsmith/randngen/raw/main/logo.png' align="right" height="300" /></a>    
+# randgen <a href='https://github.com/benyamindsmith/randngen'><img src='https://raw.githubusercontent.com/benyamindsmith/randngen/main/logo.png' align="right" height="300" /></a>    
   <a target="_blank" href="https://discord.gg/VX3pzJyfSw"><img src="https://dcbadge.limes.pink/api/server/VX3pzJyfSw" alt="" /></a>  
 
 <!--


### PR DESCRIPTION
The source url that was using github.com points to a page with the asset on it.  Need to use the raw.github.com url that points directly to the asset as the src attribute of the img tag.
Closes #6 